### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/regex-base.cabal
+++ b/regex-base.cabal
@@ -76,7 +76,7 @@ library
   build-depends: base       >= 4.3 && < 4.15
                , mtl        >= 1.1 && < 2.3
                , containers >= 0.4 && < 0.7
-               , bytestring >= 0.9 && < 0.11
+               , bytestring >= 0.9 && < 0.12
                , array      >= 0.3 && < 0.6
                , text       >= 1.2.3 && < 1.3
 


### PR DESCRIPTION
Tested locally with `cabal build -O0 --constraint='bytestring>=0.11'`.