### PR TITLE
v0.94.0.3: Drop support for GHC 7, make Prelude imports explicit

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/andreasabel/haskell-ci
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.18.0.20240225
+# version: 0.19.20250216
 #
-# REGENDATA ("0.18.0.20240225",["github","regex-base.cabal"])
+# REGENDATA ("0.19.20250216",["github","regex-base.cabal"])
 #
 name: Haskell-CI
 on:
@@ -23,23 +23,33 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:focal
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.12.1
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.12.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.4
+          - compiler: ghc-9.10.1
             compilerKind: ghc
-            compilerVersion: 9.6.4
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.8.4
+            compilerKind: ghc
+            compilerVersion: 9.8.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.6
+            compilerKind: ghc
+            compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -89,15 +99,29 @@ jobs:
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -108,21 +132,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -200,7 +215,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(regex-base)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(regex-base)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -234,30 +249,9 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: prepare for constraint sets
-        run: |
-          rm -f cabal.project.local
-      - name: constraint set text-2.1
-        run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>= 2.1' all ; fi
-      - name: constraint set containers-0.7
-        run: |
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.7' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.7' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.7' all ; fi
-      - name: constraint set bytestring-0.12
-        run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>= 0.12' all ; fi
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 See also http://pvp.haskell.org/faq
 
+## 0.94.0.3
+
+_2025-03-02 Andreas Abel_
+
+- Drop support for GHC 7
+- Make `Prelude` imports explicit, add `LANGUAGE NoImplicitPrelude`
+- Make upper bounds of dependencies major-major (all are shipped with GHC)
+- Tested with GHC 8.0 - 9.12.1
+
 ## 0.94.0.2 Revision 1
 
 _2022-05-25 Andreas Abel_

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-regex-base
 [![Hackage version](https://img.shields.io/hackage/v/regex-base.svg?label=Hackage&color=informational)](http://hackage.haskell.org/package/regex-base)
+[![Stackage Nightly](http://stackage.org/package/regex-base/badge/nightly)](http://stackage.org/nightly/package/regex-base)
+[![Stackage LTS](http://stackage.org/package/regex-base/badge/lts)](http://stackage.org/lts/package/regex-base)
 [![Haskell-CI](https://github.com/haskell-hvr/regex-base/actions/workflows/haskell-ci.yml/badge.svg?branch=master&event=push)](https://github.com/haskell-hvr/regex-base/actions/workflows/haskell-ci.yml)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+regex-base
 ==========
 
 Common interface to several Haskell implementations of regular expressions.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,19 +1,19 @@
 branches: master
 
-constraint-set bytestring-0.12
-  ghc: >= 8.2
-  constraints: bytestring ^>= 0.12
-  tests: True
-  run-tests: True
+-- constraint-set bytestring-0.12
+--   ghc: >= 8.2
+--   constraints: bytestring ^>= 0.12
+--   tests: True
+--   run-tests: True
 
-constraint-set containers-0.7
-  ghc: >= 8.2 && < 9.7
-  constraints: containers ^>= 0.7
-  tests: True
-  run-tests: True
+-- constraint-set containers-0.7
+--   ghc: >= 8.2 && < 9.7
+--   constraints: containers ^>= 0.7
+--   tests: True
+--   run-tests: True
 
-constraint-set text-2.1
-  ghc: >= 8.2
-  constraints: text ^>= 2.1
-  tests: True
-  run-tests: True
+-- constraint-set text-2.1
+--   ghc: >= 8.2
+--   constraints: text ^>= 2.1
+--   tests: True
+--   run-tests: True

--- a/regex-base.cabal
+++ b/regex-base.cabal
@@ -1,7 +1,6 @@
-cabal-version:          1.12
+cabal-version:          1.24
 name:                   regex-base
-version:                0.94.0.2
-x-revision:             4
+version:                0.94.0.3
 
 build-type:             Simple
 license:                BSD3
@@ -30,13 +29,15 @@ description:
   .
   See also <https://wiki.haskell.org/Regular_expressions> for more information.
 
-extra-source-files:
+extra-doc-files:
   ChangeLog.md
   README.md
 
 tested-with:
-  GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.12.1
+  GHC == 9.10.1
+  GHC == 9.8.4
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -54,7 +55,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/haskell-hvr/regex-base.git
-  tag:      v0.94.0.2-r4
+  tag:      v0.94.0.3
 
 library
   hs-source-dirs: src
@@ -68,28 +69,25 @@ library
   other-modules:
       Paths_regex_base
 
-  default-language: Haskell2010
-  other-extensions:
+  default-language:
+      Haskell2010
+
+  default-extensions:
+      NoImplicitPrelude
+      Safe
       MultiParamTypeClasses
       FunctionalDependencies
       TypeSynonymInstances
       FlexibleInstances
       FlexibleContexts
 
-  if impl(ghc >= 7.4)
-    default-extensions: Safe
-    build-depends: containers >= 0.4.2.1
-                 , bytestring >= 0.9.2.1
+  build-depends:
+        base        >= 4.9   && < 5
+      , containers  >= 0.5   && < 1
+      , bytestring  >= 0.10  && < 1
+      , array       >= 0.5   && < 1
+      , text        >= 1.2.3 && < 1.3 || >= 2.0 && < 3
 
-  build-depends: base       >= 4.3 && < 5
-               , containers >= 0.4 && < 0.8
-               , bytestring >= 0.9 && < 0.13
-               , array      >= 0.3 && < 0.6
-               , text       >= 1.2.3 && < 1.3 || >=2.0 && <2.2
-
-  if !impl(ghc >= 8)
-      build-depends: fail == 4.9.*
-
-  ghc-options: -Wall
-  if impl(ghc >= 8)
-    ghc-options: -Wcompat
+  ghc-options:
+      -Wall
+      -Wcompat

--- a/src/Text/Regex/Base.hs
+++ b/src/Text/Regex/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies #-}
 -----------------------------------------------------------------------------
 -- |
 --
@@ -6,7 +5,7 @@
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (MPTC+FD)
 --
@@ -72,7 +71,7 @@ module Text.Regex.Base (getVersion_Text_Regex_Base
   -- | RegexLike defines classes and type, and 'Extract' instances
   ,module Text.Regex.Base.RegexLike) where
 
-import Data.Version(Version(..))
+import Data.Version(Version)
 import Text.Regex.Base.RegexLike
 import Text.Regex.Base.Context()
 

--- a/src/Text/Regex/Base/Context.hs
+++ b/src/Text/Regex/Base/Context.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts, TypeSynonymInstances #-}
-
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-#if __GLASGOW_HASKELL__ >= 702
-{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
-#endif
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 {-|
 
@@ -12,7 +6,7 @@ Module      :  Text.Regex.Base.Context
 Copyright   :  (c) Chris Kuklewicz 2006
 SPDX-License-Identifier: BSD-3-Clause
 
-Maintainer  :  hvr@gnu.org, Andreas Abel
+Maintainer  :  Andreas Abel
 Stability   :  stable
 Portability :  non-portable (MPTC+FD)
 
@@ -192,12 +186,18 @@ Unused matches are 'empty' (defined via 'Extract')
 
 module Text.Regex.Base.Context() where
 
-import Prelude hiding (fail)
-import Control.Monad.Fail (MonadFail(fail)) -- see 'regexFailed'
+import Prelude
+  ( Int
+  , Bool(True,False)
+  , (.), ($), fmap, fst, id, return
+  , length, map
+  , pred
+  )
 
+import Control.Monad.Fail (MonadFail(fail)) -- see 'regexFailed'
 import Control.Monad(liftM)
 import Data.Array(Array,(!),elems,listArray)
---  import Data.Maybe(maybe)
+import Data.Maybe(Maybe(Nothing,Just), maybe)
 import Text.Regex.Base.RegexLike(RegexLike(..),RegexContext(..)
   ,AllSubmatches(..),AllTextSubmatches(..),AllMatches(..),AllTextMatches(..)
   ,MatchResult(..),Extract(empty),MatchOffset,MatchLength,MatchArray,MatchText)

--- a/src/Text/Regex/Base/Impl.hs
+++ b/src/Text/Regex/Base/Impl.hs
@@ -4,7 +4,7 @@
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (Text.Regex.Base needs MPTC+FD)
 --
@@ -40,7 +40,11 @@
 
 module Text.Regex.Base.Impl(polymatch,polymatchM) where
 
-import Prelude hiding (fail)
+import Prelude
+  ( Maybe(Nothing,Just)
+  , ($)
+  , fst, return
+  )
 import Control.Monad.Fail (MonadFail(fail))
 
 import Text.Regex.Base

--- a/src/Text/Regex/Base/RegexLike.hs
+++ b/src/Text/Regex/Base/RegexLike.hs
@@ -1,12 +1,10 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, FlexibleInstances, TypeSynonymInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Regex.Base.RegexLike
 -- Copyright   :  (c) Chris Kuklewicz 2006
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Maintainer  :  hvr@gnu.org, Andreas Abel
+-- Maintainer  :  Andreas Abel
 -- Stability   :  stable
 -- Portability :  non-portable (MPTC+FD)
 --
@@ -39,11 +37,18 @@ module Text.Regex.Base.RegexLike (
   AllSubmatches(..),AllTextSubmatches(..),AllMatches(..),AllTextMatches(..)
   ) where
 
-#if !MIN_VERSION_base(4,13,0)
-import Control.Monad.Fail as Fail (MonadFail)
-#endif
+import Prelude
+  (Int, Bool, String
+  , (.), (+)
+  , error, id, return, snd
+  , drop, fmap, length, map, take
+  , toEnum
+  )
+
+
+import Control.Monad.Fail (MonadFail)
 import Data.Array(Array,(!))
-import Data.Maybe(isJust)
+import Data.Maybe(Maybe,isJust,maybe)
 import qualified Data.ByteString as SB (take,drop,empty,ByteString)
 import qualified Data.ByteString.Lazy as LB (take,drop,empty,ByteString)
 import qualified Data.Sequence as S(take,drop,empty,Seq)


### PR DESCRIPTION
Harden the implementation against ecosystem changes by making the `Prelude` imports explicit.
Since there are no practical means to test this against GHC < 8, we drop support for GHC 7 explicitly, bumping to `base >= 4.9`.
All dependencies of `regex-base` ship with GHC, so maintaining precise upper bounds is just busy-work.  Thus, we make upper-bounds major-major, so we just get the very strong signals of drastic API changes.  Usual API changes should not affect this very stable package.